### PR TITLE
Feature/add support for bds

### DIFF
--- a/lib/API.php
+++ b/lib/API.php
@@ -126,7 +126,7 @@ class API
         fread($this->socket, 4096);
 
         fwrite($this->socket, sprintf(
-            "\r\n%s\r\nContent-Length: %d\r\n%s",
+            "%s\r\nContent-Length: %d\r\n\r\n%s",
             $this->deviceType->getHeader(),
             strlen($data),
             $data

--- a/lib/Devices/BDS.php
+++ b/lib/Devices/BDS.php
@@ -44,6 +44,6 @@ class BDS implements DeviceInterface
      */
     public function getHeader()
     {
-        return "POST HK_APP HTTP/1.1\r\nHost: :10025\r\nHarman Kardon BDS Remote Controller/1.0";
+        return "POST HK_APP HTTP/1.1\r\nHost: :10025\r\nUser-Agent: Harman Kardon BDS Remote Controller/1.0";
     }
 }


### PR DESCRIPTION
Hey Karim,

Here are the modifications needed to make it work on my BDS.
     - I added the user agent header name, which was there in the AVRdevice but was ommited in the BDS
     - I moved the CRLF marking the headers end in the request. The prepending CRLF was not supported on my BDS, and ther has to be a double CRLF between the last header and the payload. This modification also helps debug with wireshark, as it then decode the request as an HTTP POST, so it's easier to read.

I also checked the required changes in the headers between the AVR and the BDS version. The only difference that maters is the HK_APP insted of the AVR. But keeping the same User-Aent as your would make no difference.

Thanks a lot for your help.

Nicolas
